### PR TITLE
feat: add reason for closing issue

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -354,6 +354,7 @@ Close the specified issue.
 | actions | Action type | string | ✔ |
 | token | [Token explain](#token) | string | ✖ |
 | issue-number | The number of issue. When not input, it will be obtained from the trigger event | number | ✖ |
+| close-reason | Reason for closing. Default `not_planned`, another `completed` | string | ✖ |
 
 ⏫ [Back to list](#List)
 
@@ -856,6 +857,7 @@ jobs:
 | title-includes | Title filtering | string | ✖ |
 | inactive-day | Inactive days filtering | number | ✖ |
 | exclude-labels | Exclude labels filtering | string | ✖ |
+| close-reason | Reason for closing. Default `not_planned`, another `completed` | string | ✖ |
 
 - `labels`: When there are multiple, the query will have multiple at the same time. If not entered, all
 - `issue-assignee`: Multiplayer is not supported. If you do not enter or enter *, all will be searched. Entering `none` will query issues for which the specified person is not added
@@ -1062,6 +1064,7 @@ jobs:
 | emoji | Add [reaction](#emoji-types) for this comment | string | ✖ |
 | close-issue | Whether to close the issue at the same time | string | ✖ |
 | require-permission | Permission required, default is `write` | string | ✖ |
+| close-reason | Reason for closing. Default `not_planned`, another `completed` | string | ✖ |
 
 - `duplicate-command`: When setting concise commands, while still supporting the original `Duplicate of`. Block content contains `?`
 - `labels`: Highest priority

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ jobs:
 | actions | 操作类型 | string | ✔ |
 | token | [token 说明](#token) | string | ✖ |
 | issue-number | 指定的 issue，当不传时会从触发事件中获取 | number | ✖ |
+| close-reason | 关闭原因。默认`not_planned`未计划，`completed`完成 | string | ✖ |
 
 ⏫ [返回列表](#列-表)
 
@@ -855,6 +856,7 @@ jobs:
 | title-includes | 包含标题筛选 | string | ✖ |
 | inactive-day | 非活跃天数筛选 | number | ✖ |
 | exclude-labels | 排除标签筛选 | string | ✖ |
+| close-reason | 关闭原因。默认`not_planned`未计划，`completed`完成 | string | ✖ |
 
 - `labels`：为多个时，会查询同时拥有多个。不填时，会查询所有
 - `issue-assignee`：不支持多人。不填或输入 * 时，查询所有。输入 `none` 会查询未添加指定人的 issues
@@ -1061,6 +1063,7 @@ jobs:
 | emoji | 为该评论的增加 [emoji](#emoji-types) | string | ✖ |
 | close-issue | 是否同时关闭该 issue | string | ✖ |
 | require-permission | 要求权限，默认为 `write` | string | ✖ |
+| close-reason | 关闭原因。默认`not_planned`未计划，`completed`完成 | string | ✖ |
 
 - `duplicate-command`：当设置简洁命令时，同时仍支持原有 `Duplicate of`。屏蔽内容包含 `?`
 - `labels`：优先级最高

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,8 @@ inputs:
     description: 'Issue assignees'
   random-to:
     description: 'Issue assignees random to'
+  close-reason:
+    description: 'Issue close reason'
 
   # label
   labels:

--- a/dist/index.js
+++ b/dist/index.js
@@ -15297,7 +15297,7 @@ class IssueHelperEngine {
     }
     doExeAction(action) {
         return __awaiter(this, void 0, void 0, function* () {
-            const { issueNumber, emoji, labels, assignees, title, body, updateMode, state, ctx, closeReason } = this;
+            const { issueNumber, emoji, labels, assignees, title, body, updateMode, state, ctx, closeReason, } = this;
             switch (action) {
                 // ---[ Base Begin ]--->>>
                 case 'add-assignees': {

--- a/src/helper/advanced.ts
+++ b/src/helper/advanced.ts
@@ -6,7 +6,7 @@ import utc from 'dayjs/plugin/utc';
 
 import * as core from '../core';
 import type { IIssueCoreEngine, IListIssuesParams, TCommentInfo, TIssueList } from '../issue';
-import type { TEmoji, TIssueState, TOutList } from '../types';
+import type { TCloseReason, TEmoji, TIssueState, TOutList } from '../types';
 import { checkDuplicate, matchKeyword, replaceStr2Arr } from '../util';
 import {
   doAddAssignees,
@@ -179,13 +179,13 @@ export async function doCheckIssue() {
   core.setOutput('check-result', checkResult);
 }
 
-export async function doCloseIssues(body: string, emoji?: string) {
+export async function doCloseIssues(body: string, closeReason: TCloseReason, emoji?: string) {
   const issues = await doQueryIssues('open');
   if (issues.length) {
     for (const { number } of issues) {
       core.info(`[doCloseIssues] Doing ---> ${number}`);
       if (body) await doCreateComment(body, emoji, number);
-      await doCloseIssue(number);
+      await doCloseIssue(closeReason, number);
     }
   } else {
     core.info(`[doCloseIssues] Query issues empty!`);
@@ -293,6 +293,7 @@ export async function doMarkAssignees(comment: TCommentInfo) {
 
 export async function doMarkDuplicate(
   comment: TCommentInfo,
+  closeReason: TCloseReason,
   labels?: string[] | void,
   emoji?: string,
 ) {
@@ -345,7 +346,7 @@ export async function doMarkDuplicate(
       await doSetLabels(newLabels);
     }
     if (closeIssue === 'true') {
-      await doCloseIssue();
+      await doCloseIssue(closeReason);
     }
     core.info(`[doMarkDuplicate] Done!`);
   } else {

--- a/src/helper/base.ts
+++ b/src/helper/base.ts
@@ -21,7 +21,7 @@ export async function doAddLabels(labels: string[], issueNumber?: number) {
   core.info(`[doAddLabels] [${labels}] success!`);
 }
 
-export async function doCloseIssue(reason: TCloseReason,issueNumber?: number) {
+export async function doCloseIssue(reason: TCloseReason, issueNumber?: number) {
   if (issueNumber) ICE.setIssueNumber(issueNumber);
   await ICE.closeIssue(reason);
   core.info(`[doCloseIssue] success!`);

--- a/src/helper/base.ts
+++ b/src/helper/base.ts
@@ -3,7 +3,7 @@ import { dealStringToArr } from 'actions-util';
 import * as core from '../core';
 import type { IIssueCoreEngine } from '../issue';
 import { ELockReasons } from '../shared';
-import type { TEmoji, TIssueState, TLockReasons, TUpdateMode } from '../types';
+import type { TCloseReason, TEmoji, TIssueState, TLockReasons, TUpdateMode } from '../types';
 
 let ICE: IIssueCoreEngine;
 export function initBaseICE(_ICE: IIssueCoreEngine) {
@@ -21,9 +21,9 @@ export async function doAddLabels(labels: string[], issueNumber?: number) {
   core.info(`[doAddLabels] [${labels}] success!`);
 }
 
-export async function doCloseIssue(issueNumber?: number) {
+export async function doCloseIssue(reason: TCloseReason,issueNumber?: number) {
   if (issueNumber) ICE.setIssueNumber(issueNumber);
-  await ICE.closeIssue();
+  await ICE.closeIssue(reason);
   core.info(`[doCloseIssue] success!`);
 }
 

--- a/src/helper/helper.ts
+++ b/src/helper/helper.ts
@@ -109,7 +109,18 @@ export class IssueHelperEngine implements IIssueHelperEngine {
   }
 
   public async doExeAction(action: TAction) {
-    const { issueNumber, emoji, labels, assignees, title, body, updateMode, state, ctx, closeReason } = this;
+    const {
+      issueNumber,
+      emoji,
+      labels,
+      assignees,
+      title,
+      body,
+      updateMode,
+      state,
+      ctx,
+      closeReason,
+    } = this;
     switch (action) {
       // ---[ Base Begin ]--->>>
       case 'add-assignees': {

--- a/src/issue/issue.ts
+++ b/src/issue/issue.ts
@@ -1,7 +1,7 @@
 import { Octokit } from '@octokit/rest';
 
 import { EEmoji } from '../shared';
-import type { TEmoji, TIssueState, TLockReasons, TUpdateMode, TUserPermission } from '../types';
+import type { TEmoji, TIssueState, TLockReasons, TUpdateMode, TUserPermission, TCloseReason } from '../types';
 import type {
   IIssueBaseInfo,
   IIssueCoreEngine,
@@ -53,13 +53,14 @@ export class IssueCoreEngine implements IIssueCoreEngine {
     });
   }
 
-  public async closeIssue() {
+  public async closeIssue(reason: TCloseReason) {
     const { owner, repo, octokit, issueNumber } = this;
     await octokit.issues.update({
       owner,
       repo,
       issue_number: issueNumber,
       state: 'closed',
+      state_reason: reason,
     });
   }
 

--- a/src/issue/issue.ts
+++ b/src/issue/issue.ts
@@ -1,7 +1,14 @@
 import { Octokit } from '@octokit/rest';
 
 import { EEmoji } from '../shared';
-import type { TEmoji, TIssueState, TLockReasons, TUpdateMode, TUserPermission, TCloseReason } from '../types';
+import type {
+  TEmoji,
+  TIssueState,
+  TLockReasons,
+  TUpdateMode,
+  TUserPermission,
+  TCloseReason,
+} from '../types';
 import type {
   IIssueBaseInfo,
   IIssueCoreEngine,

--- a/src/issue/types.ts
+++ b/src/issue/types.ts
@@ -1,4 +1,4 @@
-import type { TEmoji, TIssueState, TLockReasons, TUpdateMode, TUserPermission } from '../types';
+import type { TCloseReason, TEmoji, TIssueState, TLockReasons, TUpdateMode, TUserPermission } from '../types';
 
 export interface IIssueBaseInfo {
   owner: string;
@@ -53,7 +53,7 @@ export interface IIssueCoreEngine {
   addAssignees: (assignees: string[]) => Promise<void>;
   addLabels: (labels: string[]) => Promise<void>;
 
-  closeIssue: () => Promise<void>;
+  closeIssue: (reason: TCloseReason) => Promise<void>;
   /**
    * @param body The comment body.
    * @returns The create new comment id.

--- a/src/issue/types.ts
+++ b/src/issue/types.ts
@@ -1,4 +1,11 @@
-import type { TCloseReason, TEmoji, TIssueState, TLockReasons, TUpdateMode, TUserPermission } from '../types';
+import type {
+  TCloseReason,
+  TEmoji,
+  TIssueState,
+  TLockReasons,
+  TUpdateMode,
+  TUserPermission,
+} from '../types';
 
 export interface IIssueBaseInfo {
   owner: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export type TUpdateMode = 'append' | 'replace';
 
 export type TUserPermission = TPermissionType;
 
+export type TCloseReason = 'completed' | 'not_planned';
+
 export type TOutInfo = {
   auth: string;
   id?: number;

--- a/web/.umirc.ts
+++ b/web/.umirc.ts
@@ -3,7 +3,8 @@ import { defineConfig } from 'dumi';
 
 const name = 'issues-helper';
 
-const logo = 'https://gw.alipayobjects.com/mdn/rms_f97235/afts/img/A*8xDgSL-O6O4AAAAAAAAAAAAAARQnAQ';
+const logo =
+  'https://gw.alipayobjects.com/mdn/rms_f97235/afts/img/A*8xDgSL-O6O4AAAAAAAAAAAAAARQnAQ';
 
 export default defineConfig({
   title: 'Issues Helper',

--- a/web/docs/advanced.en-US.md
+++ b/web/docs/advanced.en-US.md
@@ -134,6 +134,7 @@ jobs:
 | title-includes | Title filtering | string | ✖ |
 | inactive-day | Inactive days filtering | number | ✖ |
 | exclude-labels | Exclude labels filtering | string | ✖ |
+| close-reason | Reason for closing. Default `not_planned`, another `completed` | string | ✖ |
 
 - `labels`: When there are multiple, the query will have multiple at the same time. If not entered, all
 - `issue-assignee`: Multiplayer is not supported. If you do not enter or enter *, all will be searched. Entering `none` will query issues for which the specified person is not added
@@ -329,6 +330,7 @@ jobs:
 | emoji | Add [emoji](/en-US/guide/ref#-emoji-type) for this comment | string | ✖ |
 | close-issue | Whether to close the issue at the same time | string | ✖ |
 | require-permission | Permission required, default is `write` | string | ✖ |
+| close-reason | Reason for closing. Default `not_planned`, another `completed` | string | ✖ |
 
 - `duplicate-command`: When setting concise commands, while still supporting the original `Duplicate of`. Block content contains `?`
 - `labels`: Highest priority

--- a/web/docs/advanced.md
+++ b/web/docs/advanced.md
@@ -130,6 +130,7 @@ jobs:
 | title-includes | 包含标题筛选 | string | ✖ |
 | inactive-day | 非活跃天数筛选 | number | ✖ |
 | exclude-labels | 排除标签筛选 | string | ✖ |
+| close-reason | 关闭原因。默认`not_planned`未计划，`completed`完成 | string | ✖ |
 
 - `labels`：为多个时，会查询同时拥有多个。不填时，会查询所有
 - `issue-assignee`：不支持多人。不填或输入 * 时，查询所有。输入 `none` 会查询未添加指定人的 issues
@@ -326,6 +327,7 @@ jobs:
 | emoji | 为该评论的增加 [emoji](/guide/ref#-emoji-类型) | string | ✖ |
 | close-issue | 是否同时关闭该 issue | string | ✖ |
 | require-permission | 要求权限，默认为 `write` | string | ✖ |
+| close-reason | 关闭原因。默认`not_planned`未计划，`completed`完成 | string | ✖ |
 
 - `duplicate-command`：当设置简洁命令时，同时仍支持原有 `Duplicate of`。屏蔽内容包含 `?`
 - `labels`：优先级最高

--- a/web/docs/base.en-US.md
+++ b/web/docs/base.en-US.md
@@ -98,6 +98,7 @@ Close the specified issue.
 | actions | Action type | string | ✔ |
 | token | [Token explain](/en-US/guide/ref#-token) | string | ✖ |
 | issue-number | The number of issue. When not input, it will be obtained from the trigger event | number | ✖ |
+| close-reason | Reason for closing. Default `not_planned`, another `completed` | string | ✖ |
 
 ## `create-comment`
 

--- a/web/docs/base.md
+++ b/web/docs/base.md
@@ -98,6 +98,7 @@ jobs:
 | actions | 操作类型 | string | ✔ |
 | token | [token 说明](/guide/ref#-token-说明) | string | ✖ |
 | issue-number | 指定的 issue，当不传时会从触发事件中获取 | number | ✖ |
+| close-reason | 关闭原因。默认`not_planned`未计划，`completed`完成 | string | ✖ |
 
 ## `create-comment`
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

None


### 💡 需求背景和解决方案 / Background or solution

[GitHub Issues can now have a state reason (why they were closed)](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/#%F0%9F%95%B5%F0%9F%8F%BD%E2%99%80%EF%B8%8F-issue-closed-reasons). Currently, this action closes as complete, and there isn't an input to change that behavior.

I hava tested the `not_planned` option in [this issue](https://github.com/Xhofe/github-test/issues/1) and it works well.

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add reason for closing issue |
| 🇨🇳 Chinese | 增加关闭issue的原因 |

<!-- From: https://github.com/one-template/pr-template -->
