### PR TITLE
fix - null body case

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -10,7 +10,7 @@ export const dealRandomAssignees = (assignees: string, randomTo: string | void):
 };
 
 export const matchKeyword = (content: string = '', keywords: string[]): boolean => {
-  return !!keywords.find(item => content.toLowerCase().includes(item));
+  return !!keywords.find(item => content?.toLowerCase().includes(item));
 };
 
 export const checkDuplicate = (body: string | void): boolean => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
fixes #123 

<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
Github tasklist issue creation enables users to quickly create blank issues for items in a tasklist. When using `check-issue` or any other method that utilizes the `body-includes` filter, an issue with a null body will throw an error. 

<!--
解决的具体问题。
The specific problem solved.
-->
The solution is to utilize optional chaining - if the property of the object is undefined or null, it will not throw an error. 

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix null body case which would throw errors when using `body-includes`     |
| 🇨🇳 Chinese |           |

<!-- From: https://github.com/one-template/pr-template -->
