### PR TITLE
fix: Return assignees in the correct output field

### DIFF
--- a/src/helper/base.ts
+++ b/src/helper/base.ts
@@ -104,7 +104,7 @@ export async function doGetIssue() {
   const labelsString = labels.length ? labels.map(({ name }) => name).join(',') : '';
   core.setOutput('issue-labels', labelsString);
   const assigneesString = assignees.length ? assignees.map(({ login }) => login).join(',') : '';
-  core.setOutput('issue-body', assigneesString);
+  core.setOutput('issue-assignees', assigneesString);
 }
 
 export async function doLockIssue(issueNumber?: number) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
Fixes #162
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
Writes assignees string to the assignees field instead of overwriting the body field.
<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog
In get-issue, assignees will be returned in the issue-assignees output field, where it previously was mistakenly returned in the issue-body output field.
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

<!-- From: https://github.com/one-template/pr-template -->
