### PR TITLE
docs: document default issue filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,6 +980,7 @@ Find the current repository, the creator is k , the title contains `this` , the 
 ]
 ```
 
+- `issue-state`: The default is `open`. Other values are: `closed`, `all`
 - `direction` defaults to ascending order, only when `desc` is set, descending order will be returned
 - The `created` `updated` in the returned array, determined by the environment, will be UTC +0
 - `exclude-labels`: When set to include `$exclude-empty`, no label issue can be excluded


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [x] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue

The docs state `issue-state` as optional but dont't state the default filter applied.

https://github.com/actions-cool/issues-helper/blob/49a9184d18c4b30588f5cc62a035634f4b7b58bc/src/helper/advanced.ts#L261

### 💡 需求背景和解决方案 / Background or solution

Document the default issue filter.

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

<!-- From: https://github.com/one-template/pr-template -->
