### PR TITLE
feat: `find-comments` action `body-includes` param support multiple value

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,7 +912,7 @@ Find the current warehouse issue No. 1, the creator is k and the content contain
       token: ${{ secrets.GITHUB_TOKEN }}
       issue-number: 1
       comment-auth: 'k'
-      body-includes: 'this'
+      body-includes: 'this,that'
 ```
 
 | Param | Desc | Type | Required |
@@ -921,7 +921,7 @@ Find the current warehouse issue No. 1, the creator is k and the content contain
 | token | [Token explain](#token) | string | ✖ |
 | issue-number | The number of issue. When not input, it will be obtained from the trigger event | number | ✖ |
 | comment-auth | Comment creator, all will be queried if not filled | string | ✖ |
-| body-includes | Comment content includes filtering, no verification if not filled | string | ✖ |
+| body-includes | Comment content includes filtering, supports filtering of multiple strings, no verification if not filled | string | ✖ |
 | direction | Return `comments` sort | string | ✖ |
 
 - Return `comments` in the following format:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -914,7 +914,7 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
       issue-number: 1
       comment-auth: 'k'
-      body-includes: 'this'
+      body-includes: 'this,that'
 ```
 
 | 参数 | 描述 | 类型 | 必填 |
@@ -923,7 +923,7 @@ jobs:
 | token | [token 说明](#token) | string | ✖ |
 | issue-number | 指定的 issue，当不传时会从触发事件中获取 | number | ✖ |
 | comment-auth | 评论创建者，不填时会查询所有 | string | ✖ |
-| body-includes | 评论内容包含过滤，不填时无校验 | string | ✖ |
+| body-includes | 评论内容包含过滤，支持多个字符串过滤，不填时无校验 | string | ✖ |
 | direction | 返回 `comments` 排序 | string | ✖ |
 
 - 返回 `comments`，格式如下：

--- a/src/helper/advanced.ts
+++ b/src/helper/advanced.ts
@@ -240,7 +240,9 @@ export async function doFindComments() {
     const direction = core.getInput('direction') === 'desc' ? 'desc' : 'asc';
     for (const comment of commentList) {
       const checkUser = commentAuth ? comment.user.login === commentAuth : true;
-      const checkBody = bodyIncludes ? dealStringToArr(bodyIncludes).some(text => comment.body.includes(text)) : true;
+      const checkBody = bodyIncludes
+        ? dealStringToArr(bodyIncludes).some(text => comment.body.includes(text))
+        : true;
       if (checkUser && checkBody) {
         comments.push({
           id: comment.id,

--- a/src/helper/advanced.ts
+++ b/src/helper/advanced.ts
@@ -8,9 +8,7 @@ import * as core from '../core';
 import type { IIssueCoreEngine, IListIssuesParams, TCommentInfo, TIssueList } from '../issue';
 import { EConst } from '../shared';
 import type { TCloseReason, TEmoji, TIssueState, TOutList } from '../types';
-import { checkDuplicate, matchKeyword, replac
-  
-  eStr2Arr } from '../util';
+import { checkDuplicate, matchKeyword, replaceStr2Arr } from '../util';
 import {
   doAddAssignees,
   doAddLabels,

--- a/src/helper/advanced.ts
+++ b/src/helper/advanced.ts
@@ -8,7 +8,9 @@ import * as core from '../core';
 import type { IIssueCoreEngine, IListIssuesParams, TCommentInfo, TIssueList } from '../issue';
 import { EConst } from '../shared';
 import type { TCloseReason, TEmoji, TIssueState, TOutList } from '../types';
-import { checkDuplicate, matchKeyword, replaceStr2Arr } from '../util';
+import { checkDuplicate, matchKeyword, replac
+  
+  eStr2Arr } from '../util';
 import {
   doAddAssignees,
   doAddLabels,
@@ -240,7 +242,7 @@ export async function doFindComments() {
     const direction = core.getInput('direction') === 'desc' ? 'desc' : 'asc';
     for (const comment of commentList) {
       const checkUser = commentAuth ? comment.user.login === commentAuth : true;
-      const checkBody = bodyIncludes ? comment.body.includes(bodyIncludes) : true;
+      const checkBody = bodyIncludes ? dealStringToArr(bodyIncludes).some(text => comment.body.includes(text)) : true;
       if (checkUser && checkBody) {
         comments.push({
           id: comment.id,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [x] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
`find-comments` 操作 `body-includes` 参数支持传多个值更加灵活方便。
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  `find-comments` action `body-includes` param support multiple value |
| 🇨🇳 Chinese | `find-comments` 操作 `body-includes` 参数支持多个值 |

<!-- From: https://github.com/one-template/pr-template -->
