### PR TITLE
refactor: avoid calling `dealStringToArr` inside loop

### DIFF
--- a/src/helper/advanced.ts
+++ b/src/helper/advanced.ts
@@ -238,11 +238,13 @@ export async function doFindComments() {
     const commentAuth = core.getInput('comment-auth');
     const bodyIncludes = core.getInput('body-includes');
     const direction = core.getInput('direction') === 'desc' ? 'desc' : 'asc';
+    const bodyIncludesArr = dealStringToArr(bodyIncludes);
     for (const comment of commentList) {
       const checkUser = commentAuth ? comment.user.login === commentAuth : true;
-      const checkBody = bodyIncludes
-        ? dealStringToArr(bodyIncludes).some(text => comment.body.includes(text))
-        : true;
+      const checkBody =
+        bodyIncludesArr.length > 0
+          ? bodyIncludesArr.some(text => comment.body.includes(text))
+          : true;
       if (checkUser && checkBody) {
         comments.push({
           id: comment.id,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
--
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution
避免在for循环内部重复调用`dealStringToArr`
<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | avoid calling `dealStringToArr` inside loop |
| 🇨🇳 Chinese | 避免在循环内部重复调用`dealStringToArr` |

<!-- From: https://github.com/one-template/pr-template -->
