### PR TITLE
refactor: `check-inactive` action ignores already tagged issues

### DIFF
--- a/src/helper/advanced.ts
+++ b/src/helper/advanced.ts
@@ -160,7 +160,8 @@ export async function doCheckInactive(body: string, emoji?: string) {
     if (hasInactiveLabelIssueNumbers.length) {
       core.info(
         `[doCheckInactive] These issues already has ${inactiveLabel} label! ` +
-          JSON.stringify(hasInactiveLabelIssueNumbers) + ' total ${hasInactiveLabelIssueNumbers.length}',
+          JSON.stringify(hasInactiveLabelIssueNumbers) +
+          ' total ${hasInactiveLabelIssueNumbers.length}',
       );
     }
   } else {
@@ -335,7 +336,11 @@ export async function doLockIssues(body: string, emoji?: string) {
       }
     }
     if (hasLockedIssueNumbers.length) {
-      core.info(`[doLockIssues] Locked issues ---> ${JSON.stringify(hasLockedIssueNumbers)} total ${hasLockedIssueNumbers.length}`);
+      core.info(
+        `[doLockIssues] Locked issues ---> ${JSON.stringify(hasLockedIssueNumbers)} total ${
+          hasLockedIssueNumbers.length
+        }`,
+      );
     }
   } else {
     core.info(`[doLockIssues] Query issues empty!`);

--- a/src/helper/advanced.ts
+++ b/src/helper/advanced.ts
@@ -152,8 +152,6 @@ export async function doCheckInactive(body: string, emoji?: string) {
         core.info(`[doCheckInactive] Doing ---> ${number}`);
         await doAddLabels([inactiveLabel], number);
         if (body) await doCreateComment(body, emoji, number);
-      } else {
-        core.info(`[doCheckInactive] The issue ${number} already has ${inactiveLabel} label!`);
       }
     }
   } else {

--- a/src/helper/advanced.ts
+++ b/src/helper/advanced.ts
@@ -159,8 +159,8 @@ export async function doCheckInactive(body: string, emoji?: string) {
     }
     if (hasInactiveLabelIssueNumbers.length) {
       core.info(
-        `[doCheckInactive] Thees issues already has ${inactiveLabel} label! ` +
-          JSON.stringify(hasInactiveLabelIssueNumbers),
+        `[doCheckInactive] These issues already has ${inactiveLabel} label! ` +
+          JSON.stringify(hasInactiveLabelIssueNumbers) + ' total ${hasInactiveLabelIssueNumbers.length}',
       );
     }
   } else {
@@ -335,7 +335,7 @@ export async function doLockIssues(body: string, emoji?: string) {
       }
     }
     if (hasLockedIssueNumbers.length) {
-      core.info(`[doLockIssues] Locked issues ---> ${JSON.stringify(hasLockedIssueNumbers)}`);
+      core.info(`[doLockIssues] Locked issues ---> ${JSON.stringify(hasLockedIssueNumbers)} total ${hasLockedIssueNumbers.length}`);
     }
   } else {
     core.info(`[doLockIssues] Query issues empty!`);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [ ] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [x] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
https://github.com/element-plus/element-plus/actions/runs/20034468092/job/57452083966
随着已经打过标签的 issue 逐渐增多，越来越多相关信息被打印出来，我认为可以避免这一操作，只打印需要添加标签的 issue 信息。
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `check-inactive` action ignores already tagged issues |
| 🇨🇳 Chinese | `check-inactive` 操作忽略已标记的 issue。 |

<!-- From: https://github.com/one-template/pr-template -->
