### PR TITLE
fix: the total of inactive issues output is incorrect

### DIFF
--- a/src/helper/advanced.ts
+++ b/src/helper/advanced.ts
@@ -161,7 +161,7 @@ export async function doCheckInactive(body: string, emoji?: string) {
       core.info(
         `[doCheckInactive] These issues already has ${inactiveLabel} label! ` +
           JSON.stringify(hasInactiveLabelIssueNumbers) +
-          ' total ${hasInactiveLabelIssueNumbers.length}',
+          ` total ${hasInactiveLabelIssueNumbers.length}`,
       );
     }
   } else {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
First of all, thank you for your contribution! 😄
-->

### 🤔 这个变动的性质是？/ What is the nature of this change?

- [ ] 新特性提交 / New feature
- [x] bug 修复 / Fix bug
- [ ] 样式优化 / Style optimization
- [ ] 代码风格优化 / Code style optimization
- [ ] 性能优化 / Performance optimization
- [ ] 构建优化 / Build optimization
- [ ] 网站、文档、Demo 改进 / Website, documentation, demo improvements
- [ ] 重构代码或样式 / Refactor code or style
- [ ] 测试相关 / Test related
- [ ] 其他 / Other

### 🔗 相关 Issue / Related Issue
输出的统计 inactive 标记的issue总数信息错误。
<!--
描述相关需求的来源，如相关的 issue 讨论链接。
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 需求背景和解决方案 / Background or solution

<!--
解决的具体问题。
The specific problem solved.
-->

### 📝 更新日志 / Changelog

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | The output of the count of all issues with the inactive label is incorrect. |
| 🇨🇳 Chinese | 统计所有已经添加 inactive label 的issue总数输出错误。|

<!-- From: https://github.com/one-template/pr-template -->
